### PR TITLE
feat(projects): add projects section based on CV

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"]
 }

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -14,15 +14,7 @@ const { project } = Astro.props;
 >
 	<header class="flex flex-col gap-1">
 		<h3 class="text-accent-2 text-base font-semibold">{project.name}</h3>
-		{
-			(project.role || project.period) && (
-				<p class="text-xs text-gray-600 dark:text-gray-400">
-					{project.role}
-					{project.role && project.period ? " · " : ""}
-					{project.period}
-				</p>
-			)
-		}
+		{project.role && <p class="text-xs text-gray-600 dark:text-gray-400">{project.role}</p>}
 	</header>
 
 	<p class="text-sm leading-relaxed">{project.description}</p>

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -1,0 +1,66 @@
+---
+import { Icon } from "astro-icon/components";
+import type { Project } from "@/data/projects";
+
+interface Props {
+	project: Project;
+}
+
+const { project } = Astro.props;
+---
+
+<article
+	class="border-accent-2/15 hover:border-accent/60 group flex flex-col gap-3 rounded-md border border-dashed p-4 transition-colors"
+>
+	<header class="flex flex-col gap-1">
+		<h3 class="text-accent-2 text-base font-semibold">{project.name}</h3>
+		{
+			(project.role || project.period) && (
+				<p class="text-xs text-gray-600 dark:text-gray-400">
+					{project.role}
+					{project.role && project.period ? " · " : ""}
+					{project.period}
+				</p>
+			)
+		}
+	</header>
+
+	<p class="text-sm leading-relaxed">{project.description}</p>
+
+	{
+		project.tech.length > 0 && (
+			<ul class="flex flex-wrap gap-1.5" role="list">
+				{project.tech.map((t) => (
+					<li class="border-accent-2/20 rounded border px-1.5 py-0.5 text-[11px] font-medium">
+						{t}
+					</li>
+				))}
+			</ul>
+		)
+	}
+
+	{
+		project.links && project.links.length > 0 && (
+			<ul class="mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-1" role="list">
+				{project.links.map((link) => (
+					<li>
+						<a
+							class="cactus-link inline-flex items-center gap-1 text-xs"
+							href={link.href}
+							rel="noreferrer"
+							target="_blank"
+						>
+							<Icon
+								aria-hidden="true"
+								class="h-3.5 w-3.5"
+								focusable="false"
+								name="mdi:open-in-new"
+							/>
+							{link.label}
+						</a>
+					</li>
+				))}
+			</ul>
+		)
+	}
+</article>

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -7,13 +7,29 @@ interface Props {
 }
 
 const { project } = Astro.props;
+const primaryLink = project.links?.[0];
 ---
 
 <article
-	class="border-accent-2/15 hover:border-accent/60 group flex flex-col gap-3 rounded-md border border-dashed p-4 transition-colors"
+	class="border-accent-2/15 hover:border-accent/60 group relative flex flex-col gap-3 rounded-md border border-dashed p-4 transition-colors"
 >
 	<header class="flex flex-col gap-1">
-		<h3 class="text-accent-2 text-base font-semibold">{project.name}</h3>
+		<h3 class="text-accent-2 text-base font-semibold">
+			{
+				primaryLink ? (
+					<a
+						class="group-hover:text-accent transition-colors after:absolute after:inset-0 after:content-['']"
+						href={primaryLink.href}
+						rel="noreferrer"
+						target="_blank"
+					>
+						{project.name}
+					</a>
+				) : (
+					project.name
+				)
+			}
+		</h3>
 		<p class="text-xs text-gray-600 dark:text-gray-400">{project.summary}</p>
 	</header>
 
@@ -35,7 +51,7 @@ const { project } = Astro.props;
 		project.links && project.links.length > 0 && (
 			<ul class="mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-1" role="list">
 				{project.links.map((link) => (
-					<li>
+					<li class="relative">
 						<a
 							class="cactus-link inline-flex items-center gap-1 text-xs"
 							href={link.href}

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -10,12 +10,9 @@ const { project } = Astro.props;
 const primaryLink = project.links?.[0];
 
 const techColors: Record<string, { bg: string; text: string }> = {
-	"Java 8": { bg: "#ED8B00", text: "#1f2937" },
-	"Java 7": { bg: "#ED8B00", text: "#1f2937" },
+	Java: { bg: "#ED8B00", text: "#1f2937" },
 	"Spring Boot": { bg: "#6DB33F", text: "#1f2937" },
-	"Angular 14": { bg: "#DD0031", text: "#fff" },
 	Angular: { bg: "#DD0031", text: "#fff" },
-	"Node.js 18": { bg: "#417E38", text: "#fff" },
 	"Node.js": { bg: "#417E38", text: "#fff" },
 	Docker: { bg: "#0070C5", text: "#fff" },
 	Jenkins: { bg: "#D33833", text: "#fff" },

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -65,11 +65,16 @@ const techColors: Record<string, { bg: string; text: string }> = {
 				{project.tech.map((t) => {
 					const color = techColors[t] ?? { bg: "#6B7280", text: "#fff" };
 					return (
-						<li
-							class="tech-pill border-accent-2/20 rounded border px-1.5 py-0.5 text-[11px] font-medium transition-all duration-150"
-							style={`--pill-bg: ${color.bg}; --pill-text: ${color.text};`}
-						>
-							{t}
+						<li>
+							<button
+								aria-pressed="false"
+								class="tech-pill border-accent-2/20 cursor-pointer rounded border px-1.5 py-0.5 text-[11px] font-medium transition-all duration-150"
+								data-tech={t}
+								style={`--pill-bg: ${color.bg}; --pill-text: ${color.text};`}
+								type="button"
+							>
+								{t}
+							</button>
 						</li>
 					);
 				})}
@@ -116,7 +121,8 @@ const techColors: Record<string, { bg: string; text: string }> = {
 </article>
 
 <style>
-	.tech-pill:hover {
+	.tech-pill:hover,
+	.tech-pill[aria-pressed="true"] {
 		background-color: var(--pill-bg);
 		color: var(--pill-text);
 		border-color: var(--pill-bg);

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -14,7 +14,7 @@ const { project } = Astro.props;
 >
 	<header class="flex flex-col gap-1">
 		<h3 class="text-accent-2 text-base font-semibold">{project.name}</h3>
-		{project.role && <p class="text-xs text-gray-600 dark:text-gray-400">{project.role}</p>}
+		<p class="text-xs text-gray-600 dark:text-gray-400">{project.summary}</p>
 	</header>
 
 	<p class="text-sm leading-relaxed">{project.description}</p>

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -46,24 +46,13 @@ const techColors: Record<string, { bg: string; text: string }> = {
 ---
 
 <article
-	class="border-accent-2/15 hover:border-accent/60 group relative flex flex-col gap-3 rounded-md border border-dashed p-4 transition-colors"
+	class={`border-accent-2/15 group relative flex flex-col gap-3 rounded-md border border-dashed p-4 transition-colors${primaryLink ? " hover:border-accent/60 cursor-pointer" : ""}`}
 >
 	<header class="flex flex-col gap-1">
-		<h3 class="text-accent-2 text-base font-semibold">
-			{
-				primaryLink ? (
-					<a
-						class="group-hover:text-accent transition-colors after:absolute after:inset-0 after:content-['']"
-						href={primaryLink.href}
-						rel="noreferrer"
-						target="_blank"
-					>
-						{project.name}
-					</a>
-				) : (
-					project.name
-				)
-			}
+		<h3
+			class={`text-accent-2 text-base font-semibold${primaryLink ? " group-hover:text-accent transition-colors" : ""}`}
+		>
+			{project.name}
 		</h3>
 		<p class="text-xs text-gray-600 dark:text-gray-400">{project.summary}</p>
 	</header>
@@ -72,7 +61,7 @@ const techColors: Record<string, { bg: string; text: string }> = {
 
 	{
 		project.tech.length > 0 && (
-			<ul class="flex flex-wrap gap-1.5" role="list">
+			<ul class="relative z-10 flex flex-wrap gap-1.5" role="list">
 				{project.tech.map((t) => {
 					const color = techColors[t] ?? { bg: "#6B7280", text: "#fff" };
 					return (
@@ -90,9 +79,9 @@ const techColors: Record<string, { bg: string; text: string }> = {
 
 	{
 		project.links && project.links.length > 0 && (
-			<ul class="mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-1" role="list">
+			<ul class="relative z-10 mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-1" role="list">
 				{project.links.map((link) => (
-					<li class="relative">
+					<li>
 						<a
 							class="cactus-link inline-flex items-center gap-1 text-xs"
 							href={link.href}
@@ -110,6 +99,18 @@ const techColors: Record<string, { bg: string; text: string }> = {
 					</li>
 				))}
 			</ul>
+		)
+	}
+
+	{
+		primaryLink && (
+			<a
+				aria-label={project.name}
+				class="absolute inset-0 rounded-md"
+				href={primaryLink.href}
+				rel="noreferrer"
+				target="_blank"
+			/>
 		)
 	}
 </article>

--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -8,6 +8,41 @@ interface Props {
 
 const { project } = Astro.props;
 const primaryLink = project.links?.[0];
+
+const techColors: Record<string, { bg: string; text: string }> = {
+	"Java 8": { bg: "#ED8B00", text: "#1f2937" },
+	"Java 7": { bg: "#ED8B00", text: "#1f2937" },
+	"Spring Boot": { bg: "#6DB33F", text: "#1f2937" },
+	"Angular 14": { bg: "#DD0031", text: "#fff" },
+	Angular: { bg: "#DD0031", text: "#fff" },
+	"Node.js 18": { bg: "#417E38", text: "#fff" },
+	"Node.js": { bg: "#417E38", text: "#fff" },
+	Docker: { bg: "#0070C5", text: "#fff" },
+	Jenkins: { bg: "#D33833", text: "#fff" },
+	OpenShift: { bg: "#CC0000", text: "#fff" },
+	Git: { bg: "#CC3B18", text: "#fff" },
+	Jira: { bg: "#0052CC", text: "#fff" },
+	Servlets: { bg: "#ED8B00", text: "#1f2937" },
+	JSP: { bg: "#ED8B00", text: "#1f2937" },
+	Tomcat: { bg: "#CC3B00", text: "#fff" },
+	Apertium: { bg: "#7C3AED", text: "#fff" },
+	"SAP ABAP4": { bg: "#007DB8", text: "#fff" },
+	"SAP UI5": { bg: "#007DB8", text: "#fff" },
+	WebSockets: { bg: "#4338CA", text: "#fff" },
+	Arduino: { bg: "#007D80", text: "#fff" },
+	IoT: { bg: "#1565C0", text: "#fff" },
+	TailwindCSS: { bg: "#06B6D4", text: "#0f172a" },
+	"CI/CD": { bg: "#475569", text: "#fff" },
+	Python: { bg: "#3776AB", text: "#fff" },
+	PyTorch: { bg: "#C0380A", text: "#fff" },
+	React: { bg: "#20232A", text: "#61DAFB" },
+	"Machine Learning": { bg: "#6D28D9", text: "#fff" },
+	MongoDB: { bg: "#2E6B31", text: "#fff" },
+	"Discord API": { bg: "#5865F2", text: "#fff" },
+	TypeScript: { bg: "#3178C6", text: "#fff" },
+	Web: { bg: "#475569", text: "#fff" },
+	Astro: { bg: "#FF5D01", text: "#1f2937" },
+};
 ---
 
 <article
@@ -38,11 +73,17 @@ const primaryLink = project.links?.[0];
 	{
 		project.tech.length > 0 && (
 			<ul class="flex flex-wrap gap-1.5" role="list">
-				{project.tech.map((t) => (
-					<li class="border-accent-2/20 rounded border px-1.5 py-0.5 text-[11px] font-medium">
-						{t}
-					</li>
-				))}
+				{project.tech.map((t) => {
+					const color = techColors[t] ?? { bg: "#6B7280", text: "#fff" };
+					return (
+						<li
+							class="tech-pill border-accent-2/20 rounded border px-1.5 py-0.5 text-[11px] font-medium transition-all duration-150"
+							style={`--pill-bg: ${color.bg}; --pill-text: ${color.text};`}
+						>
+							{t}
+						</li>
+					);
+				})}
 			</ul>
 		)
 	}
@@ -72,3 +113,11 @@ const primaryLink = project.links?.[0];
 		)
 	}
 </article>
+
+<style>
+	.tech-pill:hover {
+		background-color: var(--pill-bg);
+		color: var(--pill-text);
+		border-color: var(--pill-bg);
+	}
+</style>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,9 +11,9 @@ export interface Project {
 
 export const projects: Project[] = [
 	{
-		name: "AM16 Agricultura",
+		name: "Catalonia's e-vineyard registry",
 		description:
-			"Microservices architecture for a public agriculture administration: 22 microservices built with Java 8 and Spring Boot, frontend in Angular 14. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployment and maintenance on Docker, Jenkins and OpenShift.",
+			"Microservices platform behind the e-RVC, the public registry where grape growers, wineries and regulatory councils manage plantings, harvests and wine-growing potential in Catalonia. 22 microservices in Java 8 and Spring Boot with an Angular 14 frontend. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployed on Docker, Jenkins and OpenShift.",
 		tech: [
 			"Java 8",
 			"Spring Boot",
@@ -26,14 +26,18 @@ export const projects: Project[] = [
 			"Jira",
 		],
 		links: [{ label: "ervc.agricultura.gencat.cat", href: "https://ervc.agricultura.gencat.cat" }],
-		role: "Fullstack Java Developer · Minsait (Indra)",
+		role: "Generalitat de Catalunya · Minsait (Indra)",
 	},
 	{
-		name: "AM16 Cultura",
+		name: "Catalan language services platform",
 		description:
-			"Evolution and maintenance of legacy applications for the culture sector, based on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
+			"Evolution and maintenance of the legacy applications run by the Catalan language administration — VxL (Voluntariat per la Llengua, the program that pairs Catalan learners with fluent speakers), GestCerCat (Catalan proficiency exam management), LLC (Catalan language resources portal) and RTIJ (sworn translators and interpreters registry) — built on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
 		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins"],
-		role: "Fullstack Java Developer · Minsait (Indra)",
+		links: [
+			{ label: "VxL", href: "https://www.vxl.cat" },
+			{ label: "LLC", href: "https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html" },
+		],
+		role: "Generalitat de Catalunya · Minsait (Indra)",
 	},
 	{
 		name: "SAP ABAP4 · Hotel chains",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -52,7 +52,11 @@ export const projects: Project[] = [
 		description:
 			"Web applications and platforms for an events and shows production company, including IoT-based control systems for stage illusion effects using Arduino, WebSockets and Node.js.",
 		tech: ["Node.js", "WebSockets", "Arduino", "IoT"],
-		links: [{ label: "theboxoftheboss.com", href: "https://theboxoftheboss.com" }],
+		links: [
+			{ label: "theboxoftheboss.com", href: "https://theboxoftheboss.com" },
+			{ label: "plandefuga.es", href: "https://plandefuga.es" },
+			{ label: "pedrotercero.com", href: "https://pedrotercero.com" },
+		],
 		role: "Freelance Web Developer",
 	},
 	{

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -102,8 +102,7 @@ export const projects: Project[] = [
 	{
 		name: "butler-ci-cli",
 		summary: "Terminal tooling to drive Jenkins pipelines from the command line.",
-		description:
-			"Terminal tooling to automate Jenkins pipelines straight from the command line.",
+		description: "Terminal tooling to automate Jenkins pipelines straight from the command line.",
 		tech: ["Node.js", "TypeScript", "Jenkins"],
 		links: [{ label: "GitHub", href: "https://github.com/usarral/butler-ci-cli" }],
 	},

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -7,7 +7,6 @@ export interface Project {
 		href: string;
 	}[];
 	role?: string;
-	period?: string;
 }
 
 export const projects: Project[] = [
@@ -26,9 +25,8 @@ export const projects: Project[] = [
 			"Git",
 			"Jira",
 		],
-		links: [{ label: "ervc.agricultura.gencat.com", href: "https://ervc.agricultura.gencat.com" }],
+		links: [{ label: "ervc.agricultura.gencat.cat", href: "https://ervc.agricultura.gencat.cat" }],
 		role: "Fullstack Java Developer · Minsait (Indra)",
-		period: "07/2023 — Present",
 	},
 	{
 		name: "AM16 Cultura",
@@ -36,7 +34,6 @@ export const projects: Project[] = [
 			"Evolution and maintenance of legacy applications for the culture sector, based on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
 		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins"],
 		role: "Fullstack Java Developer · Minsait (Indra)",
-		period: "07/2023 — Present",
 	},
 	{
 		name: "SAP ABAP4 · Hotel chains",
@@ -44,7 +41,6 @@ export const projects: Project[] = [
 			"Feature development and bug fixing in SAP ABAP4 for large hotel chains, including frontend work in SAP UI5 and integration with workflows based on Node.js 18 and Angular.",
 		tech: ["SAP ABAP4", "SAP UI5", "Node.js 18", "Angular"],
 		role: "SAP ABAP4 Developer · Minsait (Indra)",
-		period: "04/2023 — 06/2023",
 	},
 	{
 		name: "Various projects at The Box of the Boss",
@@ -53,7 +49,6 @@ export const projects: Project[] = [
 		tech: ["Node.js", "WebSockets", "Arduino", "IoT"],
 		links: [{ label: "theboxoftheboss.com", href: "https://theboxoftheboss.com" }],
 		role: "Freelance Web Developer",
-		period: "09/2018 — Present",
 	},
 	{
 		name: "GDM La Merced",
@@ -62,7 +57,6 @@ export const projects: Project[] = [
 		tech: ["Node.js", "Web"],
 		links: [{ label: "gdmlamerced.com", href: "https://gdmlamerced.com" }],
 		role: "Freelance Web Developer",
-		period: "09/2018 — Present",
 	},
 	{
 		name: "usarral.com",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,5 +1,3 @@
-export type ProjectCategory = "professional" | "freelance" | "personal";
-
 export interface Project {
 	name: string;
 	description: string;
@@ -8,7 +6,6 @@ export interface Project {
 		label: string;
 		href: string;
 	}[];
-	category: ProjectCategory;
 	role?: string;
 	period?: string;
 }
@@ -17,7 +14,7 @@ export const projects: Project[] = [
 	{
 		name: "AM16 Agricultura",
 		description:
-			"Arquitectura de microservicios para una administración pública del sector agrícola: 22 microservicios en Java 8 y Spring Boot, con frontend en Angular 14. Toma de requisitos directamente con cliente, análisis funcional y resolución de incidencias críticas. Despliegue y mantenimiento sobre Docker, Jenkins y OpenShift.",
+			"Microservices architecture for a public agriculture administration: 22 microservices built with Java 8 and Spring Boot, frontend in Angular 14. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployment and maintenance on Docker, Jenkins and OpenShift.",
 		tech: [
 			"Java 8",
 			"Spring Boot",
@@ -29,70 +26,65 @@ export const projects: Project[] = [
 			"Git",
 			"Jira",
 		],
-		category: "professional",
-		role: "Desarrollador Fullstack Java · Minsait (Indra)",
-		period: "07/2023 — Actualidad",
+		links: [{ label: "ervc.agricultura.gencat.com", href: "https://ervc.agricultura.gencat.com" }],
+		role: "Fullstack Java Developer · Minsait (Indra)",
+		period: "07/2023 — Present",
 	},
 	{
 		name: "AM16 Cultura",
 		description:
-			"Evolución y mantenimiento de aplicaciones legacy del sector cultural basadas en Java 7, Servlets y JSP, desplegadas sobre Tomcat 7/9.",
+			"Evolution and maintenance of legacy applications for the culture sector, based on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
 		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins"],
-		category: "professional",
-		role: "Desarrollador Fullstack Java · Minsait (Indra)",
-		period: "07/2023 — Actualidad",
+		role: "Fullstack Java Developer · Minsait (Indra)",
+		period: "07/2023 — Present",
 	},
 	{
-		name: "SAP ABAP4 · Cadenas hoteleras",
+		name: "SAP ABAP4 · Hotel chains",
 		description:
-			"Desarrollo de funcionalidades y corrección de errores en SAP ABAP4 para grandes cadenas hoteleras, incluyendo frontend en SAP UI5 e integración con flujos de trabajo basados en Node.js 18 y Angular.",
+			"Feature development and bug fixing in SAP ABAP4 for large hotel chains, including frontend work in SAP UI5 and integration with workflows based on Node.js 18 and Angular.",
 		tech: ["SAP ABAP4", "SAP UI5", "Node.js 18", "Angular"],
-		category: "professional",
-		role: "Desarrollador SAP ABAP4 · Minsait (Indra)",
+		role: "SAP ABAP4 Developer · Minsait (Indra)",
 		period: "04/2023 — 06/2023",
 	},
 	{
-		name: "I+D para espectáculos y eventos",
+		name: "Various projects at The Box of the Boss",
 		description:
-			"Desarrollo de aplicaciones y plataformas web para una empresa de producción de eventos y espectáculos, incluyendo sistemas de control para efectos de ilusionismo basados en IoT (Arduino), WebSockets y Node.js.",
+			"Web applications and platforms for an events and shows production company, including IoT-based control systems for stage illusion effects using Arduino, WebSockets and Node.js.",
 		tech: ["Node.js", "WebSockets", "Arduino", "IoT"],
-		category: "freelance",
-		role: "Web Developer · Freelance",
-		period: "09/2018 — Actualidad",
+		links: [{ label: "theboxoftheboss.com", href: "https://theboxoftheboss.com" }],
+		role: "Freelance Web Developer",
+		period: "09/2018 — Present",
 	},
 	{
 		name: "GDM La Merced",
 		description:
-			"Desarrollo y mantenimiento de la web y herramientas internas del club de balonmano local: gestión de jugadores, calendarios de partidos y publicación de resultados.",
+			"Development and maintenance of the website and internal tooling for a local handball club: player management, match calendars and results publishing.",
 		tech: ["Node.js", "Web"],
 		links: [{ label: "gdmlamerced.com", href: "https://gdmlamerced.com" }],
-		category: "freelance",
-		role: "Web Developer · Freelance",
-		period: "09/2018 — Actualidad",
+		role: "Freelance Web Developer",
+		period: "09/2018 — Present",
 	},
 	{
 		name: "usarral.com",
 		description:
-			"Web personal y blog técnico centrado en divulgación sobre desarrollo, despliegue en Docker, seguridad y automatización de sistemas. Estática, rápida y desplegada con CI/CD propio.",
+			"Personal website and technical blog focused on development, Docker deployments, security and systems automation. Static, fast and shipped through a custom CI/CD pipeline.",
 		tech: ["Astro", "Node.js", "TailwindCSS", "Docker", "CI/CD"],
 		links: [
 			{ label: "usarral.com", href: "https://usarral.com" },
 			{ label: "GitHub", href: "https://github.com/usarral/usarral.com" },
 		],
-		category: "personal",
 	},
 	{
 		name: "Astra5 · NASA Space Apps Challenge",
 		description:
-			"Herramienta de detección de inundaciones a partir de imágenes Sentinel-1, aplicando Machine Learning con PyTorch. Backend en Node.js, modelo en Python y frontend en React.",
+			"Flood detection tool built on Sentinel-1 imagery using Machine Learning with PyTorch. Backend in Node.js, model in Python and frontend in React.",
 		tech: ["Node.js", "Python", "PyTorch", "React", "Machine Learning"],
 		links: [{ label: "astra5.usarral.com", href: "https://astra5.usarral.com" }],
-		category: "personal",
 	},
 	{
 		name: "NodeBot",
 		description:
-			"Chatbot escalable para Discord construido sobre Node.js y MongoDB. Alcanzó más de 3 millones de usuarios en 27.000 servidores.",
+			"Scalable Discord chatbot built on Node.js and MongoDB. Reached more than 3 million users across 27,000 servers.",
 		tech: ["Node.js", "MongoDB", "Discord API"],
 		links: [
 			{
@@ -100,37 +92,12 @@ export const projects: Project[] = [
 				href: "https://github.com/LyricalString/Node-Discord-Bot/tree/master",
 			},
 		],
-		category: "personal",
 	},
 	{
 		name: "butler-ci-cli",
 		description:
-			"Utilidades de terminal para automatizar pipelines en Jenkins y gestionar tickets en Jira desde la línea de comandos.",
+			"Terminal tooling to automate Jenkins pipelines and manage Jira tickets straight from the command line.",
 		tech: ["Node.js", "TypeScript", "Jenkins", "Jira"],
-		category: "personal",
-	},
-	{
-		name: "Sistemas en desarrollo",
-		description:
-			"Arquitectura de aplicaciones para rutinas de ejercicio y webs corporativas, explorando distintos frameworks de servidor y de UI sobre PostgreSQL.",
-		tech: ["Node.js", "NestJS", "Next.js", "Svelte", "Astro", "PostgreSQL"],
-		category: "personal",
+		links: [{ label: "GitHub", href: "https://github.com/usarral/butler-ci-cli" }],
 	},
 ];
-
-export const categoryMeta: Record<ProjectCategory, { title: string; description: string }> = {
-	professional: {
-		title: "Experiencia profesional",
-		description: "Proyectos desarrollados como parte de mi trabajo a tiempo completo.",
-	},
-	freelance: {
-		title: "Freelance e I+D",
-		description: "Clientes y trabajos por cuenta propia, desde web hasta IoT en directo.",
-	},
-	personal: {
-		title: "Proyectos personales",
-		description: "Side projects, herramientas y experimentos que mantengo o he mantenido.",
-	},
-};
-
-export const categoryOrder: ProjectCategory[] = ["professional", "freelance", "personal"];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,7 +11,7 @@ export interface Project {
 
 export const projects: Project[] = [
 	{
-		name: "Catalonia's e-vineyard registry",
+		name: "e-RVC · Catalonia's vineyard registry",
 		description:
 			"Microservices platform behind the e-RVC, the public registry where grape growers, wineries and regulatory councils manage plantings, harvests and wine-growing potential in Catalonia. 22 microservices in Java 8 and Spring Boot with an Angular 14 frontend. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployed on Docker, Jenkins and OpenShift.",
 		tech: [
@@ -44,6 +44,7 @@ export const projects: Project[] = [
 		description:
 			"Feature development and bug fixing in SAP ABAP4 for large hotel chains, including frontend work in SAP UI5 and integration with workflows based on Node.js 18 and Angular.",
 		tech: ["SAP ABAP4", "SAP UI5", "Node.js 18", "Angular"],
+		links: [{ label: "tmsforhotels.com", href: "https://www.tmsforhotels.com/tmshotels" }],
 		role: "SAP ABAP4 Developer · Minsait (Indra)",
 	},
 	{

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -16,10 +16,10 @@ export const projects: Project[] = [
 		description:
 			"Microservices platform behind the e-RVC, the Generalitat de Catalunya's public registry where grape growers, wineries and regulatory councils manage plantings, harvests and wine-growing potential. 22 microservices in Java 8 and Spring Boot with an Angular 14 frontend. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployed on Docker, Jenkins and OpenShift.",
 		tech: [
-			"Java 8",
+			"Java",
 			"Spring Boot",
-			"Angular 14",
-			"Node.js 18",
+			"Angular",
+			"Node.js",
 			"Docker",
 			"Jenkins",
 			"OpenShift",
@@ -33,7 +33,7 @@ export const projects: Project[] = [
 		summary: "Legacy Java apps powering Catalan proficiency exams, translation and resources.",
 		description:
 			"Evolution and maintenance of the legacy applications run by the Generalitat de Catalunya's language administration — VxL (Voluntariat per la Llengua, the program that pairs Catalan learners with fluent speakers), GestCerCat (Catalan proficiency exam management), LLC (Catalan language resources portal), RTIJ (sworn translators and interpreters registry) and the in-house Apertium-based machine translators for Occitan/Aranese and the rest of the supported language pairs — built on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
-		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins", "Apertium"],
+		tech: ["Java", "Servlets", "JSP", "Tomcat", "Jenkins", "Apertium"],
 		links: [
 			{ label: "VxL", href: "https://www.vxl.cat" },
 			{ label: "LLC", href: "https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html" },
@@ -44,7 +44,7 @@ export const projects: Project[] = [
 		summary: "ABAP4 and UI5 customisations for the ERP of large hotel chains.",
 		description:
 			"Feature development and bug fixing in SAP ABAP4 for large hotel chains, including frontend work in SAP UI5 and integration with workflows based on Node.js 18 and Angular.",
-		tech: ["SAP ABAP4", "SAP UI5", "Node.js 18", "Angular"],
+		tech: ["SAP ABAP4", "SAP UI5", "Node.js", "Angular"],
 		links: [{ label: "tmsforhotels.com", href: "https://www.tmsforhotels.com/tmshotels" }],
 	},
 	{

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -31,8 +31,8 @@ export const projects: Project[] = [
 	{
 		name: "Catalan language services platform",
 		description:
-			"Evolution and maintenance of the legacy applications run by the Catalan language administration — VxL (Voluntariat per la Llengua, the program that pairs Catalan learners with fluent speakers), GestCerCat (Catalan proficiency exam management), LLC (Catalan language resources portal) and RTIJ (sworn translators and interpreters registry) — built on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
-		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins"],
+			"Evolution and maintenance of the legacy applications run by the Catalan language administration — VxL (Voluntariat per la Llengua, the program that pairs Catalan learners with fluent speakers), GestCerCat (Catalan proficiency exam management), LLC (Catalan language resources portal), RTIJ (sworn translators and interpreters registry) and the in-house Apertium-based machine translators for Occitan/Aranese and the rest of the supported language pairs — built on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
+		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins", "Apertium"],
 		links: [
 			{ label: "VxL", href: "https://www.vxl.cat" },
 			{ label: "LLC", href: "https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html" },

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,136 @@
+export type ProjectCategory = "professional" | "freelance" | "personal";
+
+export interface Project {
+	name: string;
+	description: string;
+	tech: string[];
+	links?: {
+		label: string;
+		href: string;
+	}[];
+	category: ProjectCategory;
+	role?: string;
+	period?: string;
+}
+
+export const projects: Project[] = [
+	{
+		name: "AM16 Agricultura",
+		description:
+			"Arquitectura de microservicios para una administración pública del sector agrícola: 22 microservicios en Java 8 y Spring Boot, con frontend en Angular 14. Toma de requisitos directamente con cliente, análisis funcional y resolución de incidencias críticas. Despliegue y mantenimiento sobre Docker, Jenkins y OpenShift.",
+		tech: [
+			"Java 8",
+			"Spring Boot",
+			"Angular 14",
+			"Node.js 18",
+			"Docker",
+			"Jenkins",
+			"OpenShift",
+			"Git",
+			"Jira",
+		],
+		category: "professional",
+		role: "Desarrollador Fullstack Java · Minsait (Indra)",
+		period: "07/2023 — Actualidad",
+	},
+	{
+		name: "AM16 Cultura",
+		description:
+			"Evolución y mantenimiento de aplicaciones legacy del sector cultural basadas en Java 7, Servlets y JSP, desplegadas sobre Tomcat 7/9.",
+		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins"],
+		category: "professional",
+		role: "Desarrollador Fullstack Java · Minsait (Indra)",
+		period: "07/2023 — Actualidad",
+	},
+	{
+		name: "SAP ABAP4 · Cadenas hoteleras",
+		description:
+			"Desarrollo de funcionalidades y corrección de errores en SAP ABAP4 para grandes cadenas hoteleras, incluyendo frontend en SAP UI5 e integración con flujos de trabajo basados en Node.js 18 y Angular.",
+		tech: ["SAP ABAP4", "SAP UI5", "Node.js 18", "Angular"],
+		category: "professional",
+		role: "Desarrollador SAP ABAP4 · Minsait (Indra)",
+		period: "04/2023 — 06/2023",
+	},
+	{
+		name: "I+D para espectáculos y eventos",
+		description:
+			"Desarrollo de aplicaciones y plataformas web para una empresa de producción de eventos y espectáculos, incluyendo sistemas de control para efectos de ilusionismo basados en IoT (Arduino), WebSockets y Node.js.",
+		tech: ["Node.js", "WebSockets", "Arduino", "IoT"],
+		category: "freelance",
+		role: "Web Developer · Freelance",
+		period: "09/2018 — Actualidad",
+	},
+	{
+		name: "GDM La Merced",
+		description:
+			"Desarrollo y mantenimiento de la web y herramientas internas del club de balonmano local: gestión de jugadores, calendarios de partidos y publicación de resultados.",
+		tech: ["Node.js", "Web"],
+		links: [{ label: "gdmlamerced.com", href: "https://gdmlamerced.com" }],
+		category: "freelance",
+		role: "Web Developer · Freelance",
+		period: "09/2018 — Actualidad",
+	},
+	{
+		name: "usarral.com",
+		description:
+			"Web personal y blog técnico centrado en divulgación sobre desarrollo, despliegue en Docker, seguridad y automatización de sistemas. Estática, rápida y desplegada con CI/CD propio.",
+		tech: ["Astro", "Node.js", "TailwindCSS", "Docker", "CI/CD"],
+		links: [
+			{ label: "usarral.com", href: "https://usarral.com" },
+			{ label: "GitHub", href: "https://github.com/usarral/usarral.com" },
+		],
+		category: "personal",
+	},
+	{
+		name: "Astra5 · NASA Space Apps Challenge",
+		description:
+			"Herramienta de detección de inundaciones a partir de imágenes Sentinel-1, aplicando Machine Learning con PyTorch. Backend en Node.js, modelo en Python y frontend en React.",
+		tech: ["Node.js", "Python", "PyTorch", "React", "Machine Learning"],
+		links: [{ label: "astra5.usarral.com", href: "https://astra5.usarral.com" }],
+		category: "personal",
+	},
+	{
+		name: "NodeBot",
+		description:
+			"Chatbot escalable para Discord construido sobre Node.js y MongoDB. Alcanzó más de 3 millones de usuarios en 27.000 servidores.",
+		tech: ["Node.js", "MongoDB", "Discord API"],
+		links: [
+			{
+				label: "GitHub",
+				href: "https://github.com/LyricalString/Node-Discord-Bot/tree/master",
+			},
+		],
+		category: "personal",
+	},
+	{
+		name: "butler-ci-cli",
+		description:
+			"Utilidades de terminal para automatizar pipelines en Jenkins y gestionar tickets en Jira desde la línea de comandos.",
+		tech: ["Node.js", "TypeScript", "Jenkins", "Jira"],
+		category: "personal",
+	},
+	{
+		name: "Sistemas en desarrollo",
+		description:
+			"Arquitectura de aplicaciones para rutinas de ejercicio y webs corporativas, explorando distintos frameworks de servidor y de UI sobre PostgreSQL.",
+		tech: ["Node.js", "NestJS", "Next.js", "Svelte", "Astro", "PostgreSQL"],
+		category: "personal",
+	},
+];
+
+export const categoryMeta: Record<ProjectCategory, { title: string; description: string }> = {
+	professional: {
+		title: "Experiencia profesional",
+		description: "Proyectos desarrollados como parte de mi trabajo a tiempo completo.",
+	},
+	freelance: {
+		title: "Freelance e I+D",
+		description: "Clientes y trabajos por cuenta propia, desde web hasta IoT en directo.",
+	},
+	personal: {
+		title: "Proyectos personales",
+		description: "Side projects, herramientas y experimentos que mantengo o he mantenido.",
+	},
+};
+
+export const categoryOrder: ProjectCategory[] = ["professional", "freelance", "personal"];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,19 +1,20 @@
 export interface Project {
 	name: string;
+	summary: string;
 	description: string;
 	tech: string[];
 	links?: {
 		label: string;
 		href: string;
 	}[];
-	role?: string;
 }
 
 export const projects: Project[] = [
 	{
 		name: "e-RVC · Catalonia's vineyard registry",
+		summary: "Microservices platform for Catalonia's public wine-growing registry.",
 		description:
-			"Microservices platform behind the e-RVC, the public registry where grape growers, wineries and regulatory councils manage plantings, harvests and wine-growing potential in Catalonia. 22 microservices in Java 8 and Spring Boot with an Angular 14 frontend. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployed on Docker, Jenkins and OpenShift.",
+			"Microservices platform behind the e-RVC, the Generalitat de Catalunya's public registry where grape growers, wineries and regulatory councils manage plantings, harvests and wine-growing potential. 22 microservices in Java 8 and Spring Boot with an Angular 14 frontend. Direct client work for requirements gathering, functional analysis and critical incident resolution. Deployed on Docker, Jenkins and OpenShift.",
 		tech: [
 			"Java 8",
 			"Spring Boot",
@@ -26,29 +27,29 @@ export const projects: Project[] = [
 			"Jira",
 		],
 		links: [{ label: "ervc.agricultura.gencat.cat", href: "https://ervc.agricultura.gencat.cat" }],
-		role: "Generalitat de Catalunya · Minsait (Indra)",
 	},
 	{
 		name: "Catalan language services platform",
+		summary: "Legacy Java apps powering Catalan proficiency exams, translation and resources.",
 		description:
-			"Evolution and maintenance of the legacy applications run by the Catalan language administration — VxL (Voluntariat per la Llengua, the program that pairs Catalan learners with fluent speakers), GestCerCat (Catalan proficiency exam management), LLC (Catalan language resources portal), RTIJ (sworn translators and interpreters registry) and the in-house Apertium-based machine translators for Occitan/Aranese and the rest of the supported language pairs — built on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
+			"Evolution and maintenance of the legacy applications run by the Generalitat de Catalunya's language administration — VxL (Voluntariat per la Llengua, the program that pairs Catalan learners with fluent speakers), GestCerCat (Catalan proficiency exam management), LLC (Catalan language resources portal), RTIJ (sworn translators and interpreters registry) and the in-house Apertium-based machine translators for Occitan/Aranese and the rest of the supported language pairs — built on Java 7, Servlets and JSP, deployed on Tomcat 7/9.",
 		tech: ["Java 7", "Servlets", "JSP", "Tomcat", "Jenkins", "Apertium"],
 		links: [
 			{ label: "VxL", href: "https://www.vxl.cat" },
 			{ label: "LLC", href: "https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html" },
 		],
-		role: "Generalitat de Catalunya · Minsait (Indra)",
 	},
 	{
 		name: "SAP ABAP4 · Hotel chains",
+		summary: "ABAP4 and UI5 customisations for the ERP of large hotel chains.",
 		description:
 			"Feature development and bug fixing in SAP ABAP4 for large hotel chains, including frontend work in SAP UI5 and integration with workflows based on Node.js 18 and Angular.",
 		tech: ["SAP ABAP4", "SAP UI5", "Node.js 18", "Angular"],
 		links: [{ label: "tmsforhotels.com", href: "https://www.tmsforhotels.com/tmshotels" }],
-		role: "SAP ABAP4 Developer · Minsait (Indra)",
 	},
 	{
 		name: "Various projects at The Box of the Boss",
+		summary: "Web platforms and IoT stage effects for an events production company.",
 		description:
 			"Web applications and platforms for an events and shows production company, including IoT-based control systems for stage illusion effects using Arduino, WebSockets and Node.js.",
 		tech: ["Node.js", "WebSockets", "Arduino", "IoT"],
@@ -57,18 +58,18 @@ export const projects: Project[] = [
 			{ label: "plandefuga.es", href: "https://plandefuga.es" },
 			{ label: "pedrotercero.com", href: "https://pedrotercero.com" },
 		],
-		role: "Freelance Web Developer",
 	},
 	{
 		name: "GDM La Merced",
+		summary: "Website and back-office tooling for a local handball club.",
 		description:
 			"Development and maintenance of the website and internal tooling for a local handball club: player management, match calendars and results publishing.",
 		tech: ["Node.js", "Web"],
 		links: [{ label: "gdmlamerced.com", href: "https://gdmlamerced.com" }],
-		role: "Freelance Web Developer",
 	},
 	{
 		name: "usarral.com",
+		summary: "Personal site and technical blog, statically built with Astro.",
 		description:
 			"Personal website and technical blog focused on development, Docker deployments, security and systems automation. Static, fast and shipped through a custom CI/CD pipeline.",
 		tech: ["Astro", "Node.js", "TailwindCSS", "Docker", "CI/CD"],
@@ -79,6 +80,7 @@ export const projects: Project[] = [
 	},
 	{
 		name: "Astra5 · NASA Space Apps Challenge",
+		summary: "Machine-learning flood detection on Sentinel-1 satellite imagery.",
 		description:
 			"Flood detection tool built on Sentinel-1 imagery using Machine Learning with PyTorch. Backend in Node.js, model in Python and frontend in React.",
 		tech: ["Node.js", "Python", "PyTorch", "React", "Machine Learning"],
@@ -86,6 +88,7 @@ export const projects: Project[] = [
 	},
 	{
 		name: "NodeBot",
+		summary: "Discord chatbot that reached 3M users across 27,000 servers.",
 		description:
 			"Scalable Discord chatbot built on Node.js and MongoDB. Reached more than 3 million users across 27,000 servers.",
 		tech: ["Node.js", "MongoDB", "Discord API"],
@@ -98,9 +101,10 @@ export const projects: Project[] = [
 	},
 	{
 		name: "butler-ci-cli",
+		summary: "Terminal tooling to drive Jenkins pipelines from the command line.",
 		description:
-			"Terminal tooling to automate Jenkins pipelines and manage Jira tickets straight from the command line.",
-		tech: ["Node.js", "TypeScript", "Jenkins", "Jira"],
+			"Terminal tooling to automate Jenkins pipelines straight from the command line.",
+		tech: ["Node.js", "TypeScript", "Jenkins"],
 		links: [{ label: "GitHub", href: "https://github.com/usarral/butler-ci-cli" }],
 	},
 ];

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,42 +1,23 @@
 ---
 import ProjectCard from "@/components/projects/ProjectCard.astro";
-import { categoryMeta, categoryOrder, projects } from "@/data/projects";
+import { projects } from "@/data/projects";
 import PageLayout from "@/layouts/Base.astro";
 
 const meta = {
 	description:
-		"Una selección de los proyectos en los que he trabajado: experiencia profesional, freelance y proyectos personales.",
+		"A selection of the projects I've worked on: from microservice architectures to live IoT, Discord bots and tools I use day to day.",
 	title: "Projects",
 };
-
-const grouped = categoryOrder.map((category) => ({
-	category,
-	meta: categoryMeta[category],
-	items: projects.filter((p) => p.category === category),
-}));
 ---
 
 <PageLayout meta={meta}>
 	<h1 class="title mb-4">Projects</h1>
 	<p class="mb-12 text-sm">
-		Una selección de proyectos profesionales y personales en los que he trabajado: desde
-		arquitecturas de microservicios y SAP, hasta IoT en directo, bots de Discord y herramientas
-		para automatizar mi día a día.
+		A selection of professional and personal projects I've worked on — ranging from microservice
+		architectures and SAP, to live IoT, Discord bots and tooling to automate my day to day.
 	</p>
 
-	{
-		grouped.map(({ category, meta: cat, items }) => (
-			<section class="mb-12 last:mb-0" id={category}>
-				<header class="mb-4">
-					<h2 class="text-accent-2 mb-1 text-lg font-semibold">{cat.title}</h2>
-					<p class="text-xs text-gray-600 dark:text-gray-400">{cat.description}</p>
-				</header>
-				<div class="grid gap-4 sm:grid-cols-2">
-					{items.map((project) => (
-						<ProjectCard project={project} />
-					))}
-				</div>
-			</section>
-		))
-	}
+	<div class="grid gap-4 sm:grid-cols-2">
+		{projects.map((project) => <ProjectCard project={project} />)}
+	</div>
 </PageLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -12,12 +12,72 @@ const meta = {
 
 <PageLayout meta={meta}>
 	<h1 class="title mb-4">Projects</h1>
-	<p class="mb-12 text-sm">
+	<p class="mb-6 text-sm">
 		A selection of professional and personal projects I've worked on — ranging from microservice
 		architectures and SAP, to live IoT, Discord bots and tooling to automate my day to day.
+		Click on any technology pill to filter.
 	</p>
 
-	<div class="grid gap-4 sm:grid-cols-2">
+	<div
+		class="border-accent-2/20 mb-6 flex items-center gap-2 rounded border border-dashed px-3 py-2 text-xs"
+		hidden
+		id="project-filter-banner"
+	>
+		<span>Filtering by</span>
+		<span class="text-accent-2 font-semibold" id="project-filter-label"></span>
+		<span class="text-gray-600 dark:text-gray-400" id="project-filter-count"></span>
+		<button class="cactus-link ml-auto" id="project-filter-clear" type="button">
+			Clear filter
+		</button>
+	</div>
+
+	<div class="grid gap-4 sm:grid-cols-2" id="projects-grid">
 		{projects.map((project) => <ProjectCard project={project} />)}
 	</div>
 </PageLayout>
+
+<script>
+	const banner = document.getElementById("project-filter-banner");
+	const label = document.getElementById("project-filter-label");
+	const count = document.getElementById("project-filter-count");
+	const clearBtn = document.getElementById("project-filter-clear");
+	const grid = document.getElementById("projects-grid");
+
+	if (banner && label && count && clearBtn && grid) {
+		let activeFilter: string | null = null;
+		const articles = Array.from(grid.querySelectorAll<HTMLElement>("article"));
+		const pills = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-tech]"));
+
+		const applyFilter = (tech: string | null) => {
+			activeFilter = tech;
+			let visible = 0;
+
+			for (const article of articles) {
+				const matches =
+					!tech ||
+					article.querySelector(`[data-tech="${CSS.escape(tech)}"]`) !== null;
+				article.hidden = !matches;
+				if (matches) visible += 1;
+			}
+
+			for (const pill of pills) {
+				pill.setAttribute("aria-pressed", String(pill.dataset.tech === tech));
+			}
+
+			banner.hidden = !tech;
+			if (tech) {
+				label.textContent = tech;
+				count.textContent = `· ${visible} of ${articles.length} projects`;
+			}
+		};
+
+		for (const pill of pills) {
+			pill.addEventListener("click", () => {
+				const tech = pill.dataset.tech ?? null;
+				applyFilter(activeFilter === tech ? null : tech);
+			});
+		}
+
+		clearBtn.addEventListener("click", () => applyFilter(null));
+	}
+</script>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,42 @@
+---
+import ProjectCard from "@/components/projects/ProjectCard.astro";
+import { categoryMeta, categoryOrder, projects } from "@/data/projects";
+import PageLayout from "@/layouts/Base.astro";
+
+const meta = {
+	description:
+		"Una selección de los proyectos en los que he trabajado: experiencia profesional, freelance y proyectos personales.",
+	title: "Projects",
+};
+
+const grouped = categoryOrder.map((category) => ({
+	category,
+	meta: categoryMeta[category],
+	items: projects.filter((p) => p.category === category),
+}));
+---
+
+<PageLayout meta={meta}>
+	<h1 class="title mb-4">Projects</h1>
+	<p class="mb-12 text-sm">
+		Una selección de proyectos profesionales y personales en los que he trabajado: desde
+		arquitecturas de microservicios y SAP, hasta IoT en directo, bots de Discord y herramientas
+		para automatizar mi día a día.
+	</p>
+
+	{
+		grouped.map(({ category, meta: cat, items }) => (
+			<section class="mb-12 last:mb-0" id={category}>
+				<header class="mb-4">
+					<h2 class="text-accent-2 mb-1 text-lg font-semibold">{cat.title}</h2>
+					<p class="text-xs text-gray-600 dark:text-gray-400">{cat.description}</p>
+				</header>
+				<div class="grid gap-4 sm:grid-cols-2">
+					{items.map((project) => (
+						<ProjectCard project={project} />
+					))}
+				</div>
+			</section>
+		))
+	}
+</PageLayout>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -42,6 +42,10 @@ export const menuLinks: { path: string; title: string }[] = [
 	//	title: "About",
 	//},
 	{
+		path: "/projects/",
+		title: "Projects",
+	},
+	{
 		path: "/posts/",
 		title: "Blog",
 	},


### PR DESCRIPTION
Introduces a /projects page that lists professional, freelance and personal
projects, grouped by category, with tech stacks and external links. Adds the
corresponding entry to the main navigation.