### PR TITLE
chore(renovate): enable auto-rebase and lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,9 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"]
+	"extends": ["config:recommended"],
+	"rebaseWhen": "auto",
+	"lockFileMaintenance": {
+		"enabled": true
+	},
+	"postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## Problema

Las PRs de Renovate fallan con `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` porque las ramas se quedan desactualizadas respecto a `main`: Renovate actualiza `package.json` pero el `pnpm-lock.yaml` de la rama ya no coincide con la configuración de `overrides` actual.

## Cambios

- **`rebaseWhen: "auto"`** — Renovate hace rebase automático de las PRs cuando se quedan por detrás de `main`, manteniendo el lockfile sincronizado.
- **`lockFileMaintenance: { enabled: true }`** — Crea una PR periódica dedicada a regenerar el lockfile, evitando acumulación de deuda.
- **`postUpdateOptions: ["pnpmDedupe"]`** — Ejecuta `pnpm dedupe` tras cada actualización para mantener el lockfile limpio.

## Efecto inmediato

Tras mergear, Renovate hará rebase de las 9 PRs fallidas y regenerará sus lockfiles correctamente.