### PR TITLE
ci: pin pnpm back to v10 to keep CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 10
           run_install: false
 
       - name: Setup node


### PR DESCRIPTION
#### What kind of changes does this PR include?

- Changes with larger consequences (CI / tooling)

#### Description

- Reverts the pnpm v11 bump merged in #39 back to **pnpm v10**.
- **Why:** pnpm v11 no longer reads the `pnpm` field in `package.json`. It ignored `pnpm.overrides` (the `sharp` and `yaml` security pins) and `pnpm.onlyBuiltDependencies`, so the `Check for build and type issues` job on `main` failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (overrides in the lockfile no longer matched what pnpm 11 computed). Vercel builds stayed green because they only run `astro build`, not `astro check`.
- Staying on pnpm v10 keeps the current configuration working and restores CI to green.
- Moving to pnpm v11 properly means migrating `overrides` + `onlyBuiltDependencies` from the `package.json` `pnpm` field to `pnpm-workspace.yaml` (and regenerating the lockfile). That's a separate change and can be done as a follow-up if desired.

No production/runtime impact — this only affects the pnpm version used by the GitHub Actions CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TttZtjw6ebULahiX2SMo7w

---
_Generated by [Claude Code](https://claude.ai/code/session_01TttZtjw6ebULahiX2SMo7w)_